### PR TITLE
Auto dump cypress test data

### DIFF
--- a/gantt-chart/.cypress/integration/ui.spec.js
+++ b/gantt-chart/.cypress/integration/ui.spec.js
@@ -26,7 +26,48 @@
 
 /// <reference types="cypress" />
 
-import { delay, GANTT_VIS_NAME, Y_LABEL, X_LABEL, DEFAULT_SIZE } from '../utils/constants';
+import {
+  testDataSet,
+  delay,
+  GANTT_VIS_NAME,
+  Y_LABEL,
+  X_LABEL,
+  DEFAULT_SIZE,
+} from '../utils/constants';
+
+describe('Dump test data', () => {
+  it('Indexes test data for gantt chart', () => {
+    const dumpDataSet = (url, index) =>
+      cy.request(url).then((response) => {
+        cy.request({
+          method: 'POST',
+          form: true,
+          url: 'api/console/proxy',
+          headers: {
+            'content-type': 'application/json;charset=UTF-8',
+            'osd-xsrf': true,
+          },
+          qs: {
+            path: `${index}/_bulk`,
+            method: 'POST',
+          },
+          body: response.body,
+        });
+      });
+    testDataSet.forEach(({ url, index }) => dumpDataSet(url, index));
+
+    cy.request({
+      method: 'POST',
+      failOnStatusCode: false,
+      url: 'api/saved_objects/index-pattern/jaeger',
+      headers: {
+        'content-type': 'application/json',
+        'osd-xsrf': true,
+      },
+      body: JSON.stringify({ attributes: { title: 'jaeger' } }),
+    });
+  });
+});
 
 describe('Save a gantt chart', () => {
   beforeEach(() => {

--- a/gantt-chart/.cypress/tsconfig.json
+++ b/gantt-chart/.cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "baseUrl": "../node_modules",
+    "types": ["cypress"]
+  },
+  "include": ["**/*.*"]
+}

--- a/gantt-chart/.cypress/utils/constants.js
+++ b/gantt-chart/.cypress/utils/constants.js
@@ -24,6 +24,13 @@
  *   permissions and limitations under the License.
  */
 
+export const testDataSet = [
+  {
+    url: 'https://raw.githubusercontent.com/opensearch-project/dashboards-visualizations/main/gantt-chart/.cypress/utils/jaeger-sample.json',
+    index: 'jaeger',
+  },
+];
+
 export const delay = 1000;
 export const GANTT_VIS_NAME = 'A test gantt chart ' + Math.random().toString(36).substring(2);
 export const Y_LABEL = 'A unique label for Y-axis';

--- a/gantt-chart/cypress.json
+++ b/gantt-chart/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://localhost:5601",
   "video": true,
   "fixturesFolder": ".cypress/fixtures",
   "integrationFolder": ".cypress/integration",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Dump jaeger data needed to run cypress before other tests

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
