### PR TITLE
Bump version for OpenSearch 1.2.0 release

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -6,7 +6,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: gantt-chart-dashboards
   OPENSEARCH_VERSION: '1.x'
-  OPENSEARCH_PLUGIN_VERSION: 1.1.0.0
+  OPENSEARCH_PLUGIN_VERSION: 1.2.0.0
 
 jobs:
 

--- a/gantt-chart/opensearch_dashboards.json
+++ b/gantt-chart/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "ganttChartDashboards",
-  "version": "1.1.0.0",
-  "opensearchDashboardsVersion": "1.1.0",
+  "version": "1.2.0.0",
+  "opensearchDashboardsVersion": "1.2.0",
   "requiredPlugins": [
     "visualizations",
     "data"

--- a/gantt-chart/package.json
+++ b/gantt-chart/package.json
@@ -1,8 +1,8 @@
 {
   "name": "gantt-chart-dashboards",
-  "version": "1.1.0.0",
+  "version": "1.2.0.0",
   "opensearchDashboards": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "templateVersion": "1.0.0"
   },
   "license": "Apache-2.0",

--- a/release-notes/opensearch-dashboards-visualizations.release-notes-1.2.0.0.md
+++ b/release-notes/opensearch-dashboards-visualizations.release-notes-1.2.0.0.md
@@ -1,0 +1,14 @@
+## Version 1.2.0.0 Release Notes
+
+Compatible with OpenSearch 1.2.0.0
+
+### Documentation
+* Update copyright notice in README and headers ([#35](https://github.com/opensearch-project/dashboards-visualizations/pull/35))
+
+### Maintenance
+* Remove explicit jest dependency ([#25](https://github.com/opensearch-project/dashboards-visualizations/pull/25))
+* Rename plugin-helpers config file name to be consistent with OSD ([#31](https://github.com/opensearch-project/dashboards-visualizations/pull/31))
+* Add project logo and correct links to LICENSE and NOTICE in README ([#35](https://github.com/opensearch-project/dashboards-visualizations/pull/35))
+* Add DCO check to PRs ([#37](https://github.com/opensearch-project/dashboards-visualizations/pull/37))
+* Bump version for OpenSearch 1.2.0 release ([#36](https://github.com/opensearch-project/dashboards-visualizations/pull/36))
+


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
* Bumps plugin version to 1.2.0.0
* Bumps the OSD version to 1.2.0

### Issues Resolved
Partly addresses #26 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
