### PR TITLE
[Backport 2.x] Onboard Stylelint (#229)

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,11 +1,10 @@
-
 name: Test and Build Gantt Chart
 
 on: [pull_request, push]
 
 env:
   PLUGIN_NAME: gantt-chart-dashboards
-  OPENSEARCH_VERSION: '2.x'
+  OPENSEARCH_VERSION: "2.x"
   OPENSEARCH_PLUGIN_VERSION: 2.10.0.0
 
 jobs:
@@ -67,7 +66,6 @@ jobs:
           path: ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart/build
 
   windows-build:
-
     runs-on: windows-latest
     steps:
       - name: Checkout Plugin
@@ -86,8 +84,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: './dashboards-visualizations/OpenSearch-Dashboards/.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: "./dashboards-visualizations/OpenSearch-Dashboards/.nvmrc"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Yarn
         # Need to use bash to avoid having a windows/linux specific step
@@ -108,6 +106,11 @@ jobs:
         run: |
           cd ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart
           yarn osd bootstrap
+
+      - name: Run Stylelint
+        run: |
+          cd ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart
+          yarn lint:style
 
       - name: Test
         run: |
@@ -125,9 +128,8 @@ jobs:
         with:
           name: gantt-chart-windows
           path: ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart/build
-  
-  macos-build:
 
+  macos-build:
     runs-on: macos-latest
 
     steps:
@@ -144,8 +146,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: './dashboards-visualizations/OpenSearch-Dashboards/.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          node-version-file: "./dashboards-visualizations/OpenSearch-Dashboards/.nvmrc"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Yarn
         # Need to use bash to avoid having a windows/linux specific step
@@ -167,6 +169,11 @@ jobs:
           cd ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart
           yarn osd bootstrap
 
+      - name: Run Stylelint
+        run: |
+          cd ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart
+          yarn lint:style
+
       - name: Test
         run: |
           cd ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart
@@ -183,5 +190,3 @@ jobs:
         with:
           name: gantt-chart-macos
           path: ./dashboards-visualizations/OpenSearch-Dashboards/plugins/gantt-chart/build
-
-

--- a/gantt-chart/package.json
+++ b/gantt-chart/package.json
@@ -6,6 +6,7 @@
     "osd": "node ../../scripts/osd",
     "opensearch": "node ../../scripts/opensearch",
     "lint": "eslint .",
+    "lint:style": "node ../../scripts/stylelint",
     "build": "yarn plugin-helpers build",
     "plugin-helpers": "node ../../scripts/plugin_helpers",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",

--- a/gantt-chart/public/index.scss
+++ b/gantt-chart/public/index.scss
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-.embPanel__content[data-loading][data-type=plotlyGanttChart] {
+.embPanel__content[data-loading][data-type="plotlyGanttChart"] {
   pointer-events: auto;
   filter: none;
 }


### PR DESCRIPTION
### Description
Adds new yarn lint:style script that runs Stylelint and runs it in the build and test workflow. This should help make sure new Sass isn't written with anti-patterns.

### Issues Resolved
https://github.com/opensearch-project/dashboards-visualizations/pull/229

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
